### PR TITLE
release: use gh instead of hub for GitHub Release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
-    container:
-      image: python:3
-
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -29,8 +26,8 @@ jobs:
       - name: Setup environment
         run: |
           pip install poetry
-          apt update
-          apt install -y bison hub
+          sudo apt update
+          sudo apt install -y bison
 
       - name: Install dependencies
         run: poetry install
@@ -61,7 +58,6 @@ jobs:
           VERSION=$(poetry version -s)
           echo ${VERSION} > /tmp/message
 
-          hub release create \
-            --file /tmp/message \
-            --attach dist/neologism-${VERSION}.tar.gz \
-            ${VERSION}
+          gh release create ${VERSION} \
+            --notes-file /tmp/message \
+            dist/neologism-${VERSION}.tar.gz


### PR DESCRIPTION
hub is unmaintained. gh is pre-installed on ubuntu-latest runners, so drop the python:3 container and run directly on the runner host -- the runner already ships Python 3, pip, apt, and gh. Replace `hub release create` with `gh release create`; gh picks up GITHUB_TOKEN from env automatically.

Closes #1.

Assisted-by: Claude:claude-opus-4-7