### PR TITLE
version: bump to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
+## [1.0.0] - 2026-05-20
 
 First stable release. The library has been in use through 0.0.x; this
 release commits to a public API surface and a documented semver contract.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "neologism"
-version = "0.0.8"
+version = "1.0.0"
 description = "Dynamically modifiable context-free grammar written in python"
 authors = ["Attila Szakacs <szakacs.attila96@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
The 1.0.0 changelog entry was already in place from the 1.0-preps merge; this commit just bumps pyproject.toml to match and dates the release.

Assisted-by: Claude:claude-opus-4-7