### PR TITLE
docs: install poetry deps into RTD's venv directly

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,8 @@ build:
   jobs:
     post_create_environment:
       - pip install poetry
-      - poetry config virtualenvs.create false
     post_install:
-      - poetry install
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
The previous setup relied on `poetry config virtualenvs.create false` to make `poetry install` write into the active env. That config flag turns out to be brittle on Read the Docs -- poetry didn't see RTD's venv as the active one, so the package landed somewhere sphinx-build couldn't see. The 1.0.0 stable build failed with:

    importlib.metadata.PackageNotFoundError: No package metadata
    was found for neologism

at conf.py:11, where the release string is read via `importlib.metadata.version("neologism")`.

Switch to the RTD-recommended pattern for Poetry projects: explicitly point poetry at RTD's venv via `VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH` and drop the unreliable virtualenvs.create flag.

Assisted-by: Claude:claude-opus-4-7