### PR TITLE
fix: is_finite returns True on diamond grammars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `DCFG.is_finite()` now correctly returns `True` on diamond grammars
+  (where a nonterminal is reachable from the start symbol via more
+  than one path without any cycle). The previous implementation
+  tracked "ever-visited" nodes instead of nodes currently on the DFS
+  stack, so any shared subgraph was misreported as a cycle. Sentence
+  enumeration was already correct -- the actual cycle-removal pass
+  uses a proper stack -- so the visible effect of the bug was an
+  unnecessary copy + traversal in `iter_sentences` on grammars with
+  shared subgraphs, plus any consumer call to `is_finite()` returning
+  the wrong answer.
+
 ## [1.0.0] - 2026-05-20
 
 First stable release. The library has been in use through 0.0.x; this

--- a/neologism/utils.py
+++ b/neologism/utils.py
@@ -2,19 +2,28 @@ from networkx import MultiDiGraph
 
 
 def is_multidigraph_finite(graph: MultiDiGraph, start_node) -> bool:
-    def __is_finite(_graph: MultiDiGraph, node, nodes_traversed: set):
-        if node in nodes_traversed:
+    on_stack: set = set()
+    done: set = set()
+
+    def __is_finite(node) -> bool:
+        # A node already on the DFS stack closes a cycle.
+        if node in on_stack:
             return False
+        # A node whose subtree was fully validated is reusable: this is what
+        # makes the check correct (and not exponential) on diamond patterns
+        # where two ancestors both reach the same shared subgraph.
+        if node in done:
+            return True
 
-        nodes_traversed.add(node)
-
-        for next_node in _graph.successors(node):
-            if not __is_finite(_graph, next_node, nodes_traversed):
+        on_stack.add(node)
+        for next_node in graph.successors(node):
+            if not __is_finite(next_node):
                 return False
-
+        on_stack.remove(node)
+        done.add(node)
         return True
 
-    return __is_finite(graph, start_node, set())
+    return __is_finite(start_node)
 
 
 def remove_loops_from_multidigraph(graph: MultiDiGraph, start_node) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,21 @@ def test_is_multidigraph_finite(finite_multidigraph: MultiDiGraph, infinite_mult
     assert not is_multidigraph_finite(infinite_multidigraph, "a")
 
 
+def test_is_multidigraph_finite_diamond():
+    # a -> b -> d
+    # a -> c -> d
+    # The shared `d` is reached via two independent paths. The previous
+    # implementation reported this as non-finite because it tracked
+    # "ever visited" rather than "currently on the DFS stack."
+    graph = MultiDiGraph()
+    graph.add_edge("a", "b")
+    graph.add_edge("a", "c")
+    graph.add_edge("b", "d")
+    graph.add_edge("c", "d")
+
+    assert is_multidigraph_finite(graph, "a")
+
+
 def test_remove_loops_from_multidigraph(infinite_multidigraph: MultiDiGraph):
     remove_loops_from_multidigraph(infinite_multidigraph, "a")
     assert is_multidigraph_finite(infinite_multidigraph, "a")


### PR DESCRIPTION
`is_multidigraph_finite` tracked nodes via a single "ever-visited" set that was never popped on the way out of recursion. That made any node reachable via two independent paths look like a cycle, so grammars with shared subgraphs (a common shape: two parent rules that both expand the same helper nonterminal) were reported as non-finite.

Switch to the standard DFS pattern: an `on_stack` set for cycle detection plus a `done` cache so a validated subtree is reused instead of re-traversed -- without the cache the corrected algorithm would be exponential on heavily-shared subgraphs.

The actual cycle-removal helper (`remove_loops_from_multidigraph`) was already using add-on-entry / remove-on-exit and was correct, so sentence enumeration produced the right answer even on the buggy `is_finite`. The visible effect of the bug was therefore mostly an unnecessary copy + traversal inside `DCFG.iter_sentences` for any diamond-shaped grammar, plus any consumer that called `DCFG.is_finite()` directly to gate behavior.

Add a regression test (`test_is_multidigraph_finite_diamond`) and a CHANGELOG entry under [Unreleased]. Full suite: 60/60 pass at 100% branch coverage.

Assisted-by: Claude:claude-opus-4-7